### PR TITLE
Add CSV and VCF extraction functions (See https://github.com/JellyEllie/parkinson-annotator/issues/2)

### DIFF
--- a/db_extractor.py
+++ b/db_extractor.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+class  DataExtractor: 
+
+"""
+A class for extracting Parkinson's patient data from various file types. 
+
+Methods
+-------
+
+extract_zip(zip_path, extract_to)
+        Extracts ZIP files to a directory.
+
+read_csv(file_path)
+        Reads a CSV file into a DataFrame.
+
+read_vcf(file_path)
+        Reads a VCF file into a DataFrame.
+"""
+
+	def __init__(self, data_dir="data"):
+        """
+        Initialises the extractor with a directory to store extracted files.
+        """
+	
+
+	def extract_zip:
+
+
+	def read_csv(self, file_path): 
+	
+        """Reads a CSV file into a pandas DataFrame."""
+        return pd.read_csv(file_path)
+
+	
+	def read_vcf(self, file_path):
+        """Reads a VCF file into a pandas DataFrame."""
+        rows = []
+        with open(file_path, 'r') as f:
+            for line in f:
+                if line.startswith("#"):
+                    continue
+                rows.append(line.strip().split("\t"))
+        df = pd.DataFrame(rows)
+        return df
+
+	def df_to_sqlite(args):
+	

--- a/db_extractor.py
+++ b/db_extractor.py
@@ -1,48 +1,69 @@
 #!/usr/bin/env python3
 
-class  DataExtractor: 
+import pandas as pd
+import os
 
-"""
-A class for extracting Parkinson's patient data from various file types. 
+# Script to load all patient CSVs and VCFs in ParkCSV/ as DataFrames named after the file
+import os
+import pandas as pd
 
-Methods
--------
+dataframes = {}
 
-extract_zip(zip_path, extract_to)
-        Extracts ZIP files to a directory.
-
-read_csv(file_path)
-        Reads a CSV file into a DataFrame.
-
-read_vcf(file_path)
-        Reads a VCF file into a DataFrame.
-"""
-
-	def __init__(self, data_dir="data"):
-        """
-        Initialises the extractor with a directory to store extracted files.
-        """
-	
-
-	def extract_zip:
+def standardise_columns(df):
+    # Remove spaces and lowercase all column names
+    df.columns = df.columns.str.strip().str.lower()
+    
+    # Map known column names to standard names
+    df = df.rename(columns={
+        "#chrom": "chromosome",
+        "chrom": "chromosome",
+        "pos": "position",
+        "id": "variant_id",
+        "ref": "ref",
+        "alt": "alt"
+    })
+    
+    return df
 
 
-	def read_csv(self, file_path): 
-	
-        """Reads a CSV file into a pandas DataFrame."""
-        return pd.read_csv(file_path)
+def load_csvs(csv_dir="ParkCSV"):
+    """Load all CSV files from the given directory into DataFrames."""
+    for filename in os.listdir(csv_dir):
+        if filename.endswith(".csv"):
+            base = os.path.splitext(filename)[0]
+            path = os.path.join(csv_dir, filename)
+            df = pd.read_csv(path)
+            df = standardise_columns(df)
+            dataframes[base] = df
+            print(f"Loaded CSV '{filename}' -> DataFrame '{base}' ({len(df)} rows)") #logs function on terminal
+    return dataframes
 
-	
-	def read_vcf(self, file_path):
-        """Reads a VCF file into a pandas DataFrame."""
-        rows = []
-        with open(file_path, 'r') as f:
-            for line in f:
-                if line.startswith("#"):
-                    continue
-                rows.append(line.strip().split("\t"))
-        df = pd.DataFrame(rows)
-        return df
 
-	def df_to_sqlite(args):
-	
+def load_vcfs(vcf_dir="ParkVCF"):
+    """Load all VCF files from the directory into DataFrames."""
+    for filename in os.listdir(vcf_dir):
+        if filename.endswith(".vcf"):
+            path = os.path.join(vcf_dir, filename)
+            # Define column names for VCF files
+            column_names = ["chromosome", "position", "id", "ref", "alt"]
+            # Use pandas to read VCF, automatically skipping comment lines
+            df = pd.read_csv(path, sep="\t", comment="#", names=column_names, dtype=str)
+            name = os.path.splitext(filename)[0] + "_vcf"
+            dataframes[name] = df
+            print(f"Loaded '{filename}' -> DataFrame '{name}' ({len(df)} rows)") #logs function on terminal
+    return dataframes
+
+#Test run both loaders
+load_csvs()
+load_vcfs()
+
+#Optional: Test loading all files
+if __name__ == "__main__":
+    load_csvs()
+    load_vcfs()
+    print("\nAll DataFrames loaded. Columns standardized:")
+    for name, df in dataframes.items():
+        print(name, df.columns.tolist())
+
+
+#hgvs nomenclature extractor to populate id column"

--- a/db_extractor.py
+++ b/db_extractor.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python3
-
-import pandas as pd
-import os
-
-# Script to load all patient CSVs and VCFs in ParkCSV/ as DataFrames named after the file
+"""Script to load all patient CSVs and VCFs in ParkCSV/ and ParkVCF/ as DataFrames named after the file"""
 import os
 import pandas as pd
 
 dataframes = {}
 
 def standardise_columns(df):
+    """Standardise column names for DataFrames.
+    inputs:
+        df (pd.DataFrame): DataFrame with original column names.
+    returns:
+        pd.DataFrame: DataFrame with standardised column names."
+    """
     # Remove spaces and lowercase all column names
     df.columns = df.columns.str.strip().str.lower()
-    
     # Map known column names to standard names
     df = df.rename(columns={
         "#chrom": "chromosome",
-        "chrom": "chromosome",
         "pos": "position",
         "id": "variant_id",
         "ref": "ref",
@@ -27,43 +27,44 @@ def standardise_columns(df):
 
 
 def load_csvs(csv_dir="ParkCSV"):
-    """Load all CSV files from the given directory into DataFrames."""
+    """Load all CSV files from the given directory into DataFrames.
+    inputs: 
+        csv_dir (str): Directory containing CSV files.
+    returns:
+        dict: Dictionary of DataFrames keyed by file base names."""
     for filename in os.listdir(csv_dir):
-        if filename.endswith(".csv"):
-            base = os.path.splitext(filename)[0]
-            path = os.path.join(csv_dir, filename)
-            df = pd.read_csv(path)
-            df = standardise_columns(df)
-            dataframes[base] = df
-            print(f"Loaded CSV '{filename}' -> DataFrame '{base}' ({len(df)} rows)") #logs function on terminal
+        if filename.endswith(".csv"):                                           #only process CSV files
+            base = os.path.splitext(filename)[0]                                #get base name without ".csv" extension
+            path = os.path.join(csv_dir, filename)                              #full path to file
+            df = pd.read_csv(path)                                              #load CSV into DataFrame
+            df = standardise_columns(df)                                        #standardise column names
+            dataframes[base] = df                                               #store DataFrame in dictionary      
+            print(f"Loaded CSV '{filename}' -> DataFrame '{base}' ({len(df)} rows)") #TEST: logs function on terminal
     return dataframes
 
 
 def load_vcfs(vcf_dir="ParkVCF"):
-    """Load all VCF files from the directory into DataFrames."""
-    for filename in os.listdir(vcf_dir):
-        if filename.endswith(".vcf"):
-            path = os.path.join(vcf_dir, filename)
-            # Define column names for VCF files
-            column_names = ["chromosome", "position", "id", "ref", "alt"]
-            # Use pandas to read VCF, automatically skipping comment lines
-            df = pd.read_csv(path, sep="\t", comment="#", names=column_names, dtype=str)
-            name = os.path.splitext(filename)[0] + "_vcf"
-            dataframes[name] = df
-            print(f"Loaded '{filename}' -> DataFrame '{name}' ({len(df)} rows)") #logs function on terminal
+    """Load all VCF files from the directory into DataFrames.
+    inputs:
+        vcf_dir (str): Directory containing VCF files.
+    returns:
+        dict: Dictionary of DataFrames keyed by file base names."""
+    for filename in os.listdir(vcf_dir):                                        
+        if filename.endswith(".vcf"):                                          #only process VCF files
+            path = os.path.join(vcf_dir, filename)                             #full path to file
+            column_names = ["chromosome", "position", "id", "ref", "alt"]       #standard VCF columns
+            
+            df = pd.read_csv(path, sep="\t", comment="#", names=column_names, dtype=str) #Use pandas to read VCF, automatically skipping comment lines
+            name = os.path.splitext(filename)[0] + "_vcf"                               #DataFrame name with "_vcf" suffix
+            dataframes[name] = df                                                       #store DataFrame in dictionary    
+            print(f"Loaded '{filename}' -> DataFrame '{name}' ({len(df)} rows)")        #TEST:logs function on terminal
     return dataframes
 
-#Test run both loaders
-load_csvs()
-load_vcfs()
 
-#Optional: Test loading all files
+#TEST: loading all files
 if __name__ == "__main__":
     load_csvs()
     load_vcfs()
     print("\nAll DataFrames loaded. Columns standardized:")
     for name, df in dataframes.items():
         print(name, df.columns.tolist())
-
-
-#hgvs nomenclature extractor to populate id column"


### PR DESCRIPTION
**Description:** 
- This PR adds functions to extract CSV and VCF patient files and standardises dataframe columns.
- It also includes an optional test function to load all files to verify functionality.

**Why:** 
- These changes are made to streamline data ingestion. 

**How:** 
- Added `load_csvs()` and `load_vcfs()` functions in `db_extractor.py`
- Implemented `standardise_columns()` for consistent dataframe column names
- Optional test script loads all CSVs and VCFs for verification
